### PR TITLE
Add configuration option to allow ignoring missing hooks dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ plugins {
 githook {
     gradleCommand = file("gradle_test")
     hooksDir = file(new File(rootDir, "githook_test/hooks"))
+    failOnMissingHooksDir = false
     hooks {
         "pre-commit" {
             task = "lint test"
@@ -55,6 +56,9 @@ githook {
 * hooksDir (optional)
 	* Git Hooks directory
 	* Default: `<root_dir>/.git/hooks`
+* failOnMissingHooksDir (optional)
+    * Indicates if the build should fail if the hooks dir does not exist
+    * Default `true`
 * hooks
 	* Git hook script file name. See [document](https://git-scm.com/docs/githooks).
 	*  Gradle task or shell.

--- a/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookExtension.kt
+++ b/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookExtension.kt
@@ -9,6 +9,7 @@ open class GithookExtension(project: Project) {
 
     var gradleCommand: File? = null
     var hooksDir: File? = null
+    var failOnMissingHooksDir: Boolean = true
 
     val hooks = project.container(Githook::class.java) { name ->
         Githook(name)

--- a/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookPlugin.kt
+++ b/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookPlugin.kt
@@ -12,10 +12,13 @@ class GithookPlugin : Plugin<Project> {
 
         project.afterEvaluate {
             setupExtensions(project, extension)
-            if (extension.hooksDir!!.isDirectory) HookWriter(extension).write()
-            else if (extension.failOnMissingHooksDir) throw GradleException("Can't find hooks directory: " +
-                "${extension.hooksDir}")
-            else log.info("Can't find hooks directory ${extension.hooksDir}, no hooks written")
+            if (extension.hooksDir!!.isDirectory) {
+                HookWriter(extension).write()
+            } else if (extension.failOnMissingHooksDir) {
+                throw GradleException("Can't find hooks directory: ${extension.hooksDir}")
+            } else {
+                log.info("Can't find hooks directory ${extension.hooksDir}, no hooks written")
+            }
         }
     }
 

--- a/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookPlugin.kt
+++ b/githook/src/main/kotlin/com/star_zero/gradle/githook/GithookPlugin.kt
@@ -12,7 +12,10 @@ class GithookPlugin : Plugin<Project> {
 
         project.afterEvaluate {
             setupExtensions(project, extension)
-            HookWriter(extension).write()
+            if (extension.hooksDir!!.isDirectory) HookWriter(extension).write()
+            else if (extension.failOnMissingHooksDir) throw GradleException("Can't find hooks directory: " +
+                "${extension.hooksDir}")
+            else log.info("Can't find hooks directory ${extension.hooksDir}, no hooks written")
         }
     }
 
@@ -26,9 +29,5 @@ class GithookPlugin : Plugin<Project> {
             extension.hooksDir = File(project.rootProject.rootDir, ".git/hooks")
         }
         log.debug("hooksDir: ${extension.hooksDir}")
-
-        if (!extension.hooksDir!!.isDirectory) {
-            throw GradleException("Can't find hooks directory: ${extension.hooksDir}")
-        }
     }
 }


### PR DESCRIPTION
In some situations the githooks dir may be missing due to factors outside our control (ie git clone template on build server not including hooks dir). For cases like this, it seems useful to be able to configure the plugin so that the build does not fail due to missing hooks directory.